### PR TITLE
REF: Replace TouchableOpacity with Pressable (Part 1)

### DIFF
--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -21,19 +21,7 @@ if (aspectRatio > 1.6) {
 export const BlueButtonLink = forwardRef((props, ref) => {
   const { colors } = useTheme();
   return (
-    <Pressable
-      accessibilityRole="button"
-      style={({ pressed }) => [
-        {
-          minWidth: 100,
-          minHeight: 36,
-          justifyContent: 'center',
-        },
-        pressed && { opacity: 0.6 },
-      ]}
-      {...props}
-      ref={ref}
-    >
+    <Pressable accessibilityRole="button" style={({ pressed }) => [styles.blueButtonLink, pressed && styles.pressed]} {...props} ref={ref}>
       <Text style={{ color: colors.foregroundColor, textAlign: 'center', fontSize: 16 }}>{props.title}</Text>
     </Pressable>
   );
@@ -152,3 +140,14 @@ export function BlueBigCheckmark({ style = {} }) {
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  blueButtonLink: {
+    minWidth: 100,
+    minHeight: 36,
+    justifyContent: 'center',
+  },
+  pressed: {
+    opacity: 0.6,
+  },
+});

--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -1,6 +1,6 @@
 /* eslint react/prop-types: "off", react-native/no-inline-styles: "off" */
 import React, { forwardRef } from 'react';
-import { Dimensions, I18nManager, Platform, Pressable, StyleSheet, TextInput, View } from 'react-native';
+import { Dimensions, Platform, Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Icon, Text } from '@rneui/themed';
 import { useTheme } from './components/themes';
 import { useLocale } from '@react-navigation/native';

--- a/BlueComponents.js
+++ b/BlueComponents.js
@@ -1,6 +1,6 @@
 /* eslint react/prop-types: "off", react-native/no-inline-styles: "off" */
 import React, { forwardRef } from 'react';
-import { Dimensions, I18nManager, Platform, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { Dimensions, I18nManager, Platform, Pressable, StyleSheet, TextInput, View } from 'react-native';
 import { Icon, Text } from '@rneui/themed';
 import { useTheme } from './components/themes';
 
@@ -21,18 +21,21 @@ if (aspectRatio > 1.6) {
 export const BlueButtonLink = forwardRef((props, ref) => {
   const { colors } = useTheme();
   return (
-    <TouchableOpacity
+    <Pressable
       accessibilityRole="button"
-      style={{
-        minWidth: 100,
-        minHeight: 36,
-        justifyContent: 'center',
-      }}
+      style={({ pressed }) => [
+        {
+          minWidth: 100,
+          minHeight: 36,
+          justifyContent: 'center',
+        },
+        pressed && { opacity: 0.6 },
+      ]}
       {...props}
       ref={ref}
     >
       <Text style={{ color: colors.foregroundColor, textAlign: 'center', fontSize: 16 }}>{props.title}</Text>
-    </TouchableOpacity>
+    </Pressable>
   );
 });
 

--- a/components/themes.ts
+++ b/components/themes.ts
@@ -70,6 +70,7 @@ export const BlueDefaultTheme = {
     receiveBackground: '#D1F9D6',
     receiveText: '#37C0A1',
     navigationBarColor: '#FFFFFF',
+    androidRippleColor: '#CCCCCC',
   },
 };
 
@@ -127,6 +128,7 @@ export const BlueDarkTheme: Theme = {
     receiveBackground: 'rgba(210,248,214,.2)',
     receiveText: '#37C0A1',
     navigationBarColor: '#3A3A3C',
+    androidRippleColor: '#444444',
   },
 };
 

--- a/screen/settings/About.tsx
+++ b/screen/settings/About.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Clipboard from '@react-native-clipboard/clipboard';
-import { Alert, Image, Linking, Platform, StyleSheet, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { Alert, Image, Linking, Platform, Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { getApplicationName, getBuildNumber, getBundleId, getUniqueIdSync, getVersion, hasGmsSync } from 'react-native-device-info';
 import { Icon } from '@rneui/themed';
 import Rate, { AndroidMarket } from 'react-native-rate';
@@ -136,10 +136,15 @@ const About: React.FC = () => {
           <BlueTextCentered>Nodejs</BlueTextCentered>
           <BlueTextCentered>Electrum server</BlueTextCentered>
           <BlueSpacing20 />
-          <TouchableOpacity accessibilityRole="button" onPress={handleOnGithubPress} style={[styles.buttonLink, stylesHook.buttonLink]}>
+          <Pressable
+            accessibilityRole="button"
+            onPress={handleOnGithubPress}
+            android_ripple={{ color: '#ccc' }}
+            style={({ pressed }) => [Platform.OS === 'ios' && pressed ? { opacity: 0.6 } : null, styles.buttonLink, stylesHook.buttonLink]}
+          >
             <Icon size={22} name="github" type="font-awesome-5" color={colors.foregroundColor} />
             <Text style={[styles.textLink, stylesHook.textLink]}>{formatStringAddTwoWhiteSpaces(loc.settings.about_sm_github)}</Text>
-          </TouchableOpacity>
+          </Pressable>
         </View>
       </BlueCard>
       <ListItem
@@ -210,16 +215,17 @@ const About: React.FC = () => {
       </BlueTextCentered>
       <BlueTextCentered>Unique ID: {getUniqueIdSync()}</BlueTextCentered>
       <View style={styles.copyToClipboard}>
-        <TouchableOpacity
+        <Pressable
           accessibilityRole="button"
           onPress={() => {
             const stringToCopy = 'userId:' + getUniqueIdSync();
             A.logError('copied unique id');
             Clipboard.setString(stringToCopy);
           }}
+          style={({ pressed }) => [pressed && { opacity: 0.5 }]}
         >
           <Text style={styles.copyToClipboardText}>{loc.transactions.details_copy}</Text>
-        </TouchableOpacity>
+        </Pressable>
       </View>
       <BlueSpacing20 />
       <BlueSpacing20 />

--- a/screen/settings/About.tsx
+++ b/screen/settings/About.tsx
@@ -139,8 +139,8 @@ const About: React.FC = () => {
           <Pressable
             accessibilityRole="button"
             onPress={handleOnGithubPress}
-            android_ripple={{ color: '#ccc' }}
-            style={({ pressed }) => [Platform.OS === 'ios' && pressed ? { opacity: 0.6 } : null, styles.buttonLink, stylesHook.buttonLink]}
+            android_ripple={{ color: colors.androidRippleColor }}
+            style={({ pressed }) => [Platform.OS === 'ios' && pressed ? styles.pressed : null, styles.buttonLink, stylesHook.buttonLink]}
           >
             <Icon size={22} name="github" type="font-awesome-5" color={colors.foregroundColor} />
             <Text style={[styles.textLink, stylesHook.textLink]}>{formatStringAddTwoWhiteSpaces(loc.settings.about_sm_github)}</Text>
@@ -222,7 +222,7 @@ const About: React.FC = () => {
             A.logError('copied unique id');
             Clipboard.setString(stringToCopy);
           }}
-          style={({ pressed }) => [pressed && { opacity: 0.5 }]}
+          style={({ pressed }) => [pressed && styles.pressed]}
         >
           <Text style={styles.copyToClipboardText}>{loc.transactions.details_copy}</Text>
         </Pressable>
@@ -283,5 +283,8 @@ const styles = StyleSheet.create({
   textLink: {
     marginLeft: 8,
     fontWeight: '600',
+  },
+  pressed: {
+    opacity: 0.6,
   },
 });

--- a/screen/settings/IsItMyAddress.tsx
+++ b/screen/settings/IsItMyAddress.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { Keyboard, StyleSheet, TextInput, View, ScrollView, TouchableOpacity, Text } from 'react-native';
+import { Keyboard, StyleSheet, TextInput, View, ScrollView, Text, Pressable } from 'react-native';
 import { BlueButtonLink, BlueCard, BlueSpacing10, BlueSpacing20, BlueSpacing40, BlueText } from '../../BlueComponents';
 import Button from '../../components/Button';
 import { useTheme } from '../../components/themes';
@@ -154,9 +154,9 @@ const IsItMyAddress: React.FC = () => {
             testID="AddressInput"
           />
           {address.length > 0 && (
-            <TouchableOpacity onPress={clearAddressInput} style={styles.clearButton}>
+            <Pressable onPress={clearAddressInput} style={styles.clearButton}>
               <Icon name="close" size={20} color="#81868e" />
-            </TouchableOpacity>
+            </Pressable>
           )}
         </View>
 


### PR DESCRIPTION
This PR begins the migration from TouchableOpacity to Pressable, as discussed in. Additional PRs will follow to complete the migration

### Changes included
Replaced TouchableOpacity with Pressable in:

- `BlueComponents.js`

- `screen/settings/About.tsx`

- `screen/settings/IsItMyAddress.tsx`

### Implementation notes:
Buttons with background:

- Applied `android_ripple` feedback on Android (color: "#ccc").

- Applied `opacity: 0.6` on iOS when pressed.

Text-only pressables:

- Used `opacity: 0.6` on both platforms for a consistent visual press effect.

This is a scoped update to a few files to verify if the implementation meets expectations.
Happy to iterate based on feedback before continuing with the broader migration.

