### PR TITLE
FIX: Unable to delete multiple wallets without restarting

### DIFF
--- a/hooks/useExtendedNavigation.ts
+++ b/hooks/useExtendedNavigation.ts
@@ -1,4 +1,4 @@
-import { useNavigation, NavigationProp, ParamListBase } from '@react-navigation/native';
+import { useNavigation, NavigationProp, ParamListBase, CommonActions } from '@react-navigation/native';
 import { navigationRef } from '../NavigationService';
 import { presentWalletExportReminder } from '../helpers/presentWalletExportReminder';
 import { unlockWithBiometrics, useBiometrics } from './useBiometrics';
@@ -141,8 +141,33 @@ export const useExtendedNavigation = <T extends NavigationProp<ParamListBase>>()
   );
 
   const navigateToWalletsList = useCallback(() => {
-    enhancedNavigate('WalletsList');
-  }, [enhancedNavigate]);
+  if (navigationRef.isReady()) {
+    navigationRef.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [
+          {
+            name: 'DrawerRoot',
+            state: {
+              routes: [
+                {
+                  name: 'DetailViewStackScreensStack',
+                  state: {
+                    routes: [
+                      {
+                        name: 'WalletsList',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      })
+    );
+  }
+}, []);
 
   return useMemo(
     () => ({

--- a/screen/wallets/WalletDetails.tsx
+++ b/screen/wallets/WalletDetails.tsx
@@ -41,7 +41,6 @@ import { DetailViewStackParamList } from '../../navigation/DetailViewStackParamL
 import HeaderMenuButton from '../../components/HeaderMenuButton';
 import { Action } from '../../components/types';
 import { CommonToolTipActions } from '../../typings/CommonToolTipActions';
-import { popToTop } from '../../NavigationService';
 import SafeAreaScrollView from '../../components/SafeAreaScrollView';
 import { BlueSpacing10, BlueSpacing20 } from '../../components/BlueSpacing';
 import { BlueLoading } from '../../components/BlueLoading';
@@ -68,7 +67,7 @@ const WalletDetails: React.FC = () => {
   const [hideTransactionsInWalletsList, setHideTransactionsInWalletsList] = useState<boolean>(
     wallet.getHideTransactionsInWalletsList ? !wallet.getHideTransactionsInWalletsList() : true,
   );
-  const { setOptions, navigate } = useExtendedNavigation();
+  const { setOptions, navigate, navigateToWalletsList } = useExtendedNavigation();
   const { colors } = useTheme();
   const [walletName, setWalletName] = useState<string>(wallet.getLabel());
 
@@ -93,7 +92,7 @@ const WalletDetails: React.FC = () => {
     setIsLoading(true);
     const deletionSucceeded = await handleWalletDeletion(wallet.getID());
     if (deletionSucceeded) {
-      popToTop();
+      navigateToWalletsList();
     } else {
       setIsLoading(false);
     }


### PR DESCRIPTION
Fixes: 

This PR addresses the issue where users are not able to delete multiple wallets without restarting the app

This fix uses `CommonActions.reset()` to:
- Clear the entire navigation stack
- Redirect users to `WalletsList`
- Prevent back navigation to screens associated with deleted data

I also tested `StackActions.replace()` but opted for `reset()` for a more robust and consistent navigation state.

Let me know if you would prefer a different approach or if any changes are needed,happy to adjust.
